### PR TITLE
Fix(Agenda): Prevent premature date copy on manual input

### DIFF
--- a/admin/js/main.js
+++ b/admin/js/main.js
@@ -231,7 +231,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const endDateInput = document.getElementById('dame_end_date');
 
         if (startDateInput && endDateInput) {
-            startDateInput.addEventListener('change', function() {
+            startDateInput.addEventListener('blur', function() {
                 if (this.value && !endDateInput.value) {
                     endDateInput.value = this.value;
                 }


### PR DESCRIPTION
When creating a new event in the Agenda, manually typing a start date with a four-digit year (e.g., '16/12/2025') would cause an incorrect and incomplete date (e.g., '16/12/0002') to be copied to the end date field.

This was because the 'change' event listener fired before the user had finished typing the full year.

This commit resolves the issue by changing the event listener from 'change' to 'blur'. The 'blur' event only triggers after the user has finished typing and the input field loses focus, ensuring that the complete date is copied to the end date field. This fix does not affect the behavior when using the date picker.