### PR TITLE
fix(agenda): Correctly encode location name in geo URL

### DIFF
--- a/includes/cpt.php
+++ b/includes/cpt.php
@@ -298,7 +298,7 @@ function dame_display_event_details( $content ) {
                 // Navigation buttons
                 $details_html .= '<div class="nav-buttons">';
                 $details_html .= '<a href="https://www.google.com/maps/dir/?api=1&destination=' . esc_attr( $latitude ) . ',' . esc_attr( $longitude ) . '" target="_blank" class="button nav-button">📱 ' . __( 'Calculer l\'itinéraire', 'dame' ) . '</a>';
-                $details_html .= '<a href="geo:' . esc_attr( $latitude ) . ',' . esc_attr( $longitude ) . '?q=' . esc_attr( $latitude ) . ',' . esc_attr( $longitude ) . '(' . esc_attr( $location ) . ')" class="button nav-button">🧭 ' . __( 'Ouvrir dans le GPS', 'dame' ) . '</a>';
+                $details_html .= '<a href="geo:' . esc_attr( $latitude ) . ',' . esc_attr( $longitude ) . '?q=' . esc_attr( $latitude ) . ',' . esc_attr( $longitude ) . '(' . urlencode( $location ) . ')" class="button nav-button">🧭 ' . __( 'Ouvrir dans le GPS', 'dame' ) . '</a>';
                 $details_html .= '</div>';
                 $details_html .= '</div>';
             }


### PR DESCRIPTION
The `geo:` URL for the "Open in GPS" button was using `esc_attr()` to encode the location name label. This is incorrect for URL components and could cause issues if the location name contains special characters.

This commit replaces `esc_attr()` with the correct `urlencode()` function for the location name in the `geo:` URI. This ensures the URL is always well-formed.