### PR TITLE
fix(agenda): Improve GPS button compatibility for iOS

### DIFF
--- a/includes/cpt.php
+++ b/includes/cpt.php
@@ -298,7 +298,7 @@ function dame_display_event_details( $content ) {
                 // Navigation buttons
                 $details_html .= '<div class="nav-buttons">';
                 $details_html .= '<a href="https://www.google.com/maps/dir/?api=1&destination=' . esc_attr( $latitude ) . ',' . esc_attr( $longitude ) . '" target="_blank" class="button nav-button">📱 ' . __( 'Calculer l\'itinéraire', 'dame' ) . '</a>';
-                $details_html .= '<a href="geo:' . esc_attr( $latitude ) . ',' . esc_attr( $longitude ) . '?q=' . esc_attr( $latitude ) . ',' . esc_attr( $longitude ) . '(' . urlencode( $location ) . ')" class="button nav-button">🧭 ' . __( 'Ouvrir dans le GPS', 'dame' ) . '</a>';
+                $details_html .= '<button id="dame-open-gps" data-lat="' . esc_attr( $latitude ) . '" data-lng="' . esc_attr( $longitude ) . '" class="button nav-button">🧭 ' . __( 'Ouvrir dans le GPS', 'dame' ) . '</button>';
                 $details_html .= '</div>';
                 $details_html .= '</div>';
             }

--- a/public/js/agenda.js
+++ b/public/js/agenda.js
@@ -387,4 +387,29 @@ jQuery(document).ready(function($) {
 
     // Initial Load
     fetchAndRenderCalendar();
+
+    // Handler for the "Open in GPS" button
+    $(document).on('click', '#dame-open-gps', function() {
+        const button = $(this);
+        const lat = button.data('lat');
+        const lng = button.data('lng');
+
+        if (!lat || !lng) {
+            return;
+        }
+
+        // Check for iOS
+        const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+
+        let url;
+        if (isIOS) {
+            // Apple Maps URL scheme
+            url = `https://maps.apple.com/?q=${lat},${lng}`;
+        } else {
+            // Google Maps URL scheme for all other platforms
+            url = `https://www.google.com/maps/search/?api=1&query=${lat},${lng}`;
+        }
+
+        window.open(url, '_blank');
+    });
 });


### PR DESCRIPTION
The `geo:` URI scheme is not well-supported on iOS devices. This commit improves the "Open in GPS" functionality by implementing OS detection.

- The "Open in GPS" link is now a `<button>` element with data attributes for coordinates.
- A JavaScript handler is added to `public/js/agenda.js`.
- On click, the script detects if the user is on iOS.
- It opens `maps.apple.com` for iOS users and `google.com/maps` for all other users, providing a more reliable experience across platforms.