### PR TITLE
fix(agenda): Enqueue agenda script on single event pages

### DIFF
--- a/includes/assets.php
+++ b/includes/assets.php
@@ -21,5 +21,10 @@ function dame_enqueue_public_assets() {
         array(),
         DAME_VERSION
     );
+
+    // Enqueue the agenda script on single event pages for the GPS button functionality.
+    if ( is_singular( 'dame_agenda' ) ) {
+        wp_enqueue_script( 'dame-agenda-script', plugin_dir_url( __FILE__ ) . '../public/js/agenda.js', array( 'jquery' ), DAME_VERSION, true );
+    }
 }
 add_action( 'wp_enqueue_scripts', 'dame_enqueue_public_assets' );


### PR DESCRIPTION
The `agenda.js` script, which contains the logic for the "Open in GPS" button, was only being enqueued on pages with the `[dame_agenda]` shortcode. It was not loaded on single event pages, causing the button to be non-functional.

This commit updates `includes/assets.php` to correctly enqueue `agenda.js` on single `dame_agenda` post pages, ensuring the GPS button works as intended.