### PR TITLE
Feat/dame admin bar menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 3.1.6 - 2025-09-19
+*   **Fonctionnalité :** Ajout d'un menu "DAME" à la barre d'administration de WordPress (Toolbar) pour un accès rapide aux fonctions clés du plugin. Le menu est visible sur le front-end et le back-end pour les utilisateurs connectés et inclut des liens pour "Voir les préinscriptions", "Envoyer un article", et une option pour "Faire une sauvegarde" manuelle (accessible aux administrateurs uniquement).
 *   **Correctif :** Le filtrage des catégories dans l'agenda (`[dame_agenda]`) a été corrigé. La désélection d'une catégorie enfant masque désormais correctement ses événements, même si la catégorie parente reste sélectionnée.
 *   **Correctif :** Le filtre de recherche textuel de l'agenda (`[dame_agenda]`) se réinitialise maintenant correctement lorsque le champ est vidé avec la croix du navigateur.
 

--- a/dame.php
+++ b/dame.php
@@ -149,6 +149,7 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/access-control.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/shortcodes.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/ics-generator.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/pdf-generator.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/toolbar.php';
 
 if ( is_admin() ) {
     require_once plugin_dir_path( __FILE__ ) . 'admin/menu.php';

--- a/includes/toolbar.php
+++ b/includes/toolbar.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * File for handling the admin toolbar menu.
+ *
+ * @package DAME
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+/**
+ * Adds the DAME menu to the WordPress admin bar.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+ */
+function dame_add_admin_bar_menu( $wp_admin_bar ) {
+    // Add the main DAME menu item.
+    $wp_admin_bar->add_node(
+        array(
+            'id'    => 'dame_menu',
+            'title' => '<span class="ab-icon">&#x265F;</span>' . __( 'DAME', 'dame' ),
+            'href'  => admin_url( 'edit.php?post_type=adherent' ),
+        )
+    );
+
+    // Add the "Voir les préinscription" sub-menu item.
+    $wp_admin_bar->add_node(
+        array(
+            'id'     => 'dame_view_preinscriptions',
+            'parent' => 'dame_menu',
+            'title'  => __( 'Voir les préinscriptions', 'dame' ),
+            'href'   => admin_url( 'edit.php?post_type=dame_pre_inscription' ),
+        )
+    );
+
+    // Add the "Envoyer un article" sub-menu item.
+    $wp_admin_bar->add_node(
+        array(
+            'id'     => 'dame_send_article',
+            'parent' => 'dame_menu',
+            'title'  => __( 'Envoyer un article', 'dame' ),
+            'href'   => admin_url( 'edit.php?post_type=adherent&page=dame-mailing' ),
+        )
+    );
+
+    // Add the "Faire une sauvegarde" sub-menu item.
+    $backup_url = add_query_arg(
+        array(
+            'action' => 'dame_manual_backup',
+            '_wpnonce' => wp_create_nonce( 'dame_manual_backup_nonce' ),
+        ),
+        admin_url( 'admin.php' )
+    );
+
+    $wp_admin_bar->add_node(
+        array(
+            'id'     => 'dame_manual_backup',
+            'parent' => 'dame_menu',
+            'title'  => __( 'Faire une sauvegarde', 'dame' ),
+            'href'   => $backup_url,
+        )
+    );
+}
+add_action( 'admin_bar_menu', 'dame_add_admin_bar_menu', 999 );
+
+/**
+ * Handles the manual backup trigger from the admin bar.
+ */
+function dame_handle_manual_backup() {
+    if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_GET['_wpnonce'] ), 'dame_manual_backup_nonce' ) ) {
+        wp_die( __( 'Invalid nonce.', 'dame' ) );
+    }
+
+    if ( ! current_user_can( 'manage_options' ) ) {
+        wp_die( __( 'You do not have sufficient permissions to perform this action.', 'dame' ) );
+    }
+
+    // Trigger the backup.
+    dame_do_scheduled_backup();
+
+    // Redirect back to the dashboard with a success message.
+    wp_safe_redirect( add_query_arg( 'dame_backup_triggered', '1', admin_url() ) );
+    exit;
+}
+add_action( 'admin_action_dame_manual_backup', 'dame_handle_manual_backup' );
+
+/**
+ * Displays an admin notice when the manual backup is triggered.
+ */
+function dame_show_manual_backup_notice() {
+    if ( isset( $_GET['dame_backup_triggered'] ) && '1' === $_GET['dame_backup_triggered'] ) {
+        ?>
+        <div class="notice notice-success is-dismissible">
+            <p><?php esc_html_e( 'La sauvegarde manuelle a été déclenchée. Les fichiers de sauvegarde seront envoyés à l\'adresse e-mail configurée.', 'dame' ); ?></p>
+        </div>
+        <?php
+    }
+}
+add_action( 'admin_notices', 'dame_show_manual_backup_notice' );


### PR DESCRIPTION
Adds a "DAME" menu to the WordPress admin bar, visible on both the front-end and back-end for logged-in users.

The menu includes a chess pawn icon and provides quick links to:
- View pre-inscriptions (`dame_pre_inscription` CPT).
- Send an article (`dame-mailing` page).
- Trigger a manual backup.
