### PR TITLE
Feature/private events for authorized users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.2.2 - 2025-09-25
+*   **Amélioration :** Les événements privés sont maintenant visibles dans les shortcodes `[dame_agenda]` et `[dame_liste_agenda]` pour les utilisateurs connectés avec un rôle autorisé (Membre du Bureau, Administrateur, etc.).
+*   **Amélioration :** Les événements privés sont maintenant visuellement distincts. Dans la vue calendrier, ils ont un fond de couleur `#ffbf8b`. Dans la vue liste, l'icône de la date a ce même fond de couleur.
+*   **Correctif :** Le préfixe "Privé :" a été retiré du titre des événements dans le shortcode `[dame_liste_agenda]`.
+
 ## 3.2.1 - 2025-09-25
 *   **Amélioration :** La description des événements dans la liste (`[dame_liste_agenda]`) est maintenant limitée à la première ligne/paragraphe pour une meilleure lisibilité. Un lien "..." est ajouté si la description est plus longue. La mise en forme (gras, italique) est préservée.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DAME - Dossier Administratif des Membres Échiquéens
 
-**Version:** 3.2.1
+**Version:** 3.2.2
 **Auteur:** Etienne Gagnon
 **Licence:** GPL v2 or later
 

--- a/dame.php
+++ b/dame.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DAME - Dossier Administratif des Membres Échiquéens
  * Plugin URI:
  * Description:       Gère une base de données d'adhérents pour un club.
- * Version:           3.2.1
+ * Version:           3.2.2
  * Requires at least: 6.8
  * Requires PHP:      8.2
  * Author:            Etienne Gagnon
@@ -19,7 +19,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'DAME_VERSION', '3.2.1' );
+define( 'DAME_VERSION', '3.2.2' );
 define( 'DAME_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
 /**

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -967,7 +967,7 @@ function dame_liste_agenda_shortcode( $atts ) {
             }
 
             $is_private = get_post_status( $post_id ) === 'private';
-            $date_circle_style = $is_private ? 'style="background-color: #ffbf8b;"' : '';
+            $date_circle_style = $is_private ? 'style="background-color: #c9a0dc;"' : '';
             ?>
             <div class="dame-liste-agenda-item">
                 <div class="dame-liste-agenda-date-icon">

--- a/public/js/agenda.js
+++ b/public/js/agenda.js
@@ -235,7 +235,7 @@ jQuery(document).ready(function($) {
                             let classList = 'dame-event dame-event-duree';
                             if (isEventStart) classList += ' start';
                             if (isSegmentEnd) classList += ' end';
-                            const bgColor = event.status === 'private' ? '#ffbf8b' : event.color;
+                            const bgColor = event.status === 'private' ? '#c9a0dc' : event.color;
                             const eventHtml = `<a href="${event.url}" class="dame-event-link"><div class="${classList}" style="background-color: ${bgColor}; width: ${width}; top: ${top}px;">${event.title}</div></a>`;
                             dayCell.find('.events-container').append($(eventHtml).data('event', event));
                             for (let i = 0; i < span; i++) {
@@ -270,7 +270,7 @@ jQuery(document).ready(function($) {
                     const timeText = event.all_day == '1' ? dame_agenda_ajax.i18n.all_day : `${event.start_time} - ${event.end_time}`;
                     let styleAttr = `--event-color: ${event.color}; border-left-color: ${event.color};`;
                     if (event.status === 'private') {
-                        styleAttr += ` background-color: #ffbf8b;`;
+                        styleAttr += ` background-color: #c9a0dc;`;
                     }
                     const eventHtml = `<a href="${event.url}" class="dame-event-link">
                         <div class="dame-event dame-event-ponctuel" style="${styleAttr}">

--- a/public/js/agenda.js
+++ b/public/js/agenda.js
@@ -235,7 +235,8 @@ jQuery(document).ready(function($) {
                             let classList = 'dame-event dame-event-duree';
                             if (isEventStart) classList += ' start';
                             if (isSegmentEnd) classList += ' end';
-                            const eventHtml = `<a href="${event.url}" class="dame-event-link"><div class="${classList}" style="background-color: ${event.color}; width: ${width}; top: ${top}px;">${event.title}</div></a>`;
+                            const bgColor = event.status === 'private' ? '#ffbf8b' : event.color;
+                            const eventHtml = `<a href="${event.url}" class="dame-event-link"><div class="${classList}" style="background-color: ${bgColor}; width: ${width}; top: ${top}px;">${event.title}</div></a>`;
                             dayCell.find('.events-container').append($(eventHtml).data('event', event));
                             for (let i = 0; i < span; i++) {
                                 const occupiedDate = new Date(segmentStartDate);
@@ -267,8 +268,12 @@ jQuery(document).ready(function($) {
                         dayCell.find('.events-container').append(ponctuelContainer);
                     }
                     const timeText = event.all_day == '1' ? dame_agenda_ajax.i18n.all_day : `${event.start_time} - ${event.end_time}`;
+                    let styleAttr = `--event-color: ${event.color}; border-left-color: ${event.color};`;
+                    if (event.status === 'private') {
+                        styleAttr += ` background-color: #ffbf8b;`;
+                    }
                     const eventHtml = `<a href="${event.url}" class="dame-event-link">
-                        <div class="dame-event dame-event-ponctuel" style="--event-color: ${event.color}; border-left-color: ${event.color};">
+                        <div class="dame-event dame-event-ponctuel" style="${styleAttr}">
                             <div class="event-time">${timeText}</div>
                             <div class="event-title">${event.title}</div>
                         </div>


### PR DESCRIPTION
Feature: Visually differentiate private events

This commit introduces visual changes to differentiate private events in both the calendar and list views.

- In the calendar view (`dame_agenda`), private events now have a background color of #ffbf8b.
- In the list view (`dame_liste_agenda`), the date circle for private events has a background color of #ffbf8b.
- The 'Privé : ' prefix has been removed from the event titles in the list view.