### PR TITLE
Fix undefined DAME_URL constant

### DIFF
--- a/includes/Admin/Assets.php
+++ b/includes/Admin/Assets.php
@@ -46,18 +46,18 @@ class Assets {
 		// Register Common JS
 		wp_register_script(
 			'dame-admin-common',
-			DAME_URL . 'assets/js/admin-common.js',
+			\DAME_PLUGIN_URL . 'assets/js/admin-common.js',
 			[],
-			DAME_VERSION,
+			\DAME_VERSION,
 			true
 		);
 
 		// Enqueue Common CSS (Autocomplete styles)
 		wp_enqueue_style(
 			'dame-admin-common-css',
-			DAME_URL . 'assets/css/admin-adherent.css', // Using existing file as common CSS
+			\DAME_PLUGIN_URL . 'assets/css/admin-adherent.css', // Using existing file as common CSS
 			[],
-			DAME_VERSION
+			\DAME_VERSION
 		);
 
 		// Localize Common Data
@@ -83,9 +83,9 @@ class Assets {
 		if ( $is_adherent_cpt ) {
 			wp_enqueue_script(
 				'dame-admin-adherent',
-				DAME_URL . 'assets/js/admin-adherent.js',
+				\DAME_PLUGIN_URL . 'assets/js/admin-adherent.js',
 				[ 'dame-admin-common' ], // Depends on common
-				DAME_VERSION,
+				\DAME_VERSION,
 				true
 			);
 		}
@@ -93,9 +93,9 @@ class Assets {
 		if ( $is_pre_inscription_cpt ) {
 			wp_enqueue_style(
 				'dame-admin-dame-css',
-				DAME_URL . 'assets/css/admin-dame.css',
+				\DAME_PLUGIN_URL . 'assets/css/admin-dame.css',
 				[],
-				DAME_VERSION
+				\DAME_VERSION
 			);
 		}
 	}

--- a/includes/Admin/Pages/Mailing.php
+++ b/includes/Admin/Pages/Mailing.php
@@ -50,9 +50,9 @@ class Mailing {
 
 		wp_enqueue_script(
 			'dame-mailing-js',
-			DAME_URL . 'admin/js/mailing.js', // Assuming this file exists.
+			\DAME_PLUGIN_URL . 'admin/js/mailing.js', // Assuming this file exists.
 			array( 'jquery' ),
-			DAME_VERSION,
+			\DAME_VERSION,
 			true
 		);
 	}


### PR DESCRIPTION
Fixed a PHP Fatal Error `Undefined constant "DAME\Admin\DAME_URL"` by replacing `DAME_URL` with `\DAME_PLUGIN_URL` in `includes/Admin/Assets.php` and `includes/Admin/Pages/Mailing.php`. Also updated usages of `DAME_VERSION` to `\DAME_VERSION` to explicitly refer to the global scope from within namespaced PHP files according to the project's memory directives.

---
*PR created automatically by Jules for task [10702035032134529841](https://jules.google.com/task/10702035032134529841) started by @Trollinou*