### PR TITLE
Fix Message Admin Columns Fallback for Legacy Data

### DIFF
--- a/includes/Admin/Columns/Message.php
+++ b/includes/Admin/Columns/Message.php
@@ -51,10 +51,13 @@ class Message {
 			case 'sent_date':
 				$status = get_post_meta( $post_id, '_dame_message_status', true );
 				if ( 'sent' === $status || 'sending' === $status || 'scheduled' === $status ) {
-					// We could store the actual sent date, but for now modified date or cron schedule time is a proxy.
-					// Or just show status if not fully sent.
 					if ( 'sent' === $status ) {
-						echo esc_html( get_the_modified_date( 'd/m/Y H:i', $post_id ) );
+						$old_sent_date = get_post_meta( $post_id, '_dame_sent_date', true );
+						if ( ! empty( $old_sent_date ) ) {
+							echo esc_html( get_date_from_gmt( date( 'Y-m-d H:i:s', $old_sent_date ), 'd/m/Y H:i' ) );
+						} else {
+							echo esc_html( get_the_modified_date( 'd/m/Y H:i', $post_id ) );
+						}
 					} else {
 						echo esc_html( ucfirst( $status ) );
 					}
@@ -64,21 +67,23 @@ class Message {
 				break;
 
 			case 'sending_author':
-				$author_id = get_post_field( 'post_author', $post_id );
-				$user      = get_userdata( $author_id );
+				$author_id = get_post_meta( $post_id, '_dame_sending_author', true );
+				if ( empty( $author_id ) ) {
+					$author_id = get_post_field( 'post_author', $post_id );
+				}
+				$user = get_userdata( $author_id );
 				echo $user ? esc_html( $user->display_name ) : '—';
 				break;
 
 			case 'recipients':
-				$count = (int) get_post_meta( $post_id, '_dame_message_recipients_count', true );
+				$count = get_post_meta( $post_id, '_dame_message_recipients_count', true );
+				if ( '' === $count ) {
+					$count = get_post_meta( $post_id, '_dame_total_recipients', true );
+				}
+				$count = (int) $count;
+
 				if ( $count > 0 ) {
 					echo esc_html( $count );
-					// In a real scenario, we might list names in a tooltip, but retrieving names for 100+ people is heavy here.
-					// Instructions say: "Tooltip avec les noms si > 15".
-					// This implies we should fetch them? Or maybe just "if count is small"?
-					// The instruction is "Tooltip avec les noms si > 15" -> likely means "Show names in tooltip, truncate if > 15" OR "Only show if < 15"?
-					// Actually "Tooltip avec les noms si > 15" is ambiguous. It likely means "Show recipients count. Add tooltip with names. If > 15, maybe truncate?".
-					// Let's assume a simple tooltip.
 				} else {
 					echo '0';
 				}
@@ -89,7 +94,12 @@ class Message {
 				$table_name = $wpdb->prefix . 'dame_message_opens';
 				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 				$opens = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(DISTINCT email_hash) FROM $table_name WHERE message_id = %d", $post_id ) );
-				$total = (int) get_post_meta( $post_id, '_dame_message_recipients_count', true );
+
+				$total = get_post_meta( $post_id, '_dame_message_recipients_count', true );
+				if ( '' === $total ) {
+					$total = get_post_meta( $post_id, '_dame_total_recipients', true );
+				}
+				$total = (int) $total;
 
 				if ( $total > 0 ) {
 					$percentage = round( ( $opens / $total ) * 100 );

--- a/includes/Admin/Columns/Message.php
+++ b/includes/Admin/Columns/Message.php
@@ -54,7 +54,11 @@ class Message {
 					if ( 'sent' === $status ) {
 						$old_sent_date = get_post_meta( $post_id, '_dame_sent_date', true );
 						if ( ! empty( $old_sent_date ) ) {
-							echo esc_html( get_date_from_gmt( date( 'Y-m-d H:i:s', $old_sent_date ), 'd/m/Y H:i' ) );
+							if ( is_numeric( $old_sent_date ) ) {
+								echo esc_html( get_date_from_gmt( date( 'Y-m-d H:i:s', (int) $old_sent_date ), 'd/m/Y H:i' ) );
+							} else {
+								echo esc_html( get_date_from_gmt( $old_sent_date, 'd/m/Y H:i' ) );
+							}
 						} else {
 							echo esc_html( get_the_modified_date( 'd/m/Y H:i', $post_id ) );
 						}

--- a/includes/Admin/Pages/BackupAdherent.php
+++ b/includes/Admin/Pages/BackupAdherent.php
@@ -77,7 +77,7 @@ class BackupAdherent {
 					const importForm = document.getElementById('dame-import-form');
 					if (importForm) {
 						importForm.addEventListener('submit', function(e) {
-							if (!confirm("<?php echo esc_js( __( 'Êtes-vous sûr de vouloir restaurer cette sauvegarde ? Toutes les données d\\'adhérents existantes seront supprimées et remplacées. Cette action est irréversible.', 'dame' ) ); ?>")) {
+							if (!confirm("<?php echo esc_js( __( "Êtes-vous sûr de vouloir restaurer cette sauvegarde ? Toutes les données d'adhérents existantes seront supprimées et remplacées. Cette action est irréversible.", 'dame' ) ); ?>")) {
 								e.preventDefault();
 							}
 						});
@@ -85,7 +85,7 @@ class BackupAdherent {
 					const importCsvForm = document.getElementById('dame-import-csv-form');
 					if (importCsvForm) {
 						importCsvForm.addEventListener('submit', function(e) {
-							if (!confirm("<?php echo esc_js( __( 'Êtes-vous sûr de vouloir importer ce fichier CSV ?', 'dame' ) ); ?>")) {
+							if (!confirm("<?php echo esc_js( __( "Êtes-vous sûr de vouloir importer ce fichier CSV ?", 'dame' ) ); ?>")) {
 								e.preventDefault();
 							}
 						});

--- a/includes/Admin/Pages/BackupAdherent.php
+++ b/includes/Admin/Pages/BackupAdherent.php
@@ -1,0 +1,98 @@
+<?php
+namespace DAME\Admin\Pages;
+
+class BackupAdherent {
+
+	public function init() {
+		add_action( 'admin_menu', [ $this, 'add_menu_page' ] );
+	}
+
+	public function add_menu_page() {
+		add_submenu_page(
+			'edit.php?post_type=adherent',
+			__( 'Sauvegarde / Restauration', 'dame' ),
+			__( 'Sauvegarde / Restauration', 'dame' ),
+			'manage_options',
+			'dame-backup-adherent',
+			[ $this, 'render' ]
+		);
+	}
+
+	public function render() {
+		?>
+		<div class="wrap">
+			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+
+			<div class="dame-import-export-wrapper">
+				<div class="dame-export-section" style="margin-bottom: 2em; padding: 15px; background: #fff; border: 1px solid #ccd0d4; box-shadow: 0 1px 1px rgba(0,0,0,.04);">
+					<h2><?php esc_html_e( 'Sauvegarder ou Exporter les données', 'dame' ); ?></h2>
+					<p><?php esc_html_e( "Cliquez sur l'un des boutons ci-dessous pour télécharger les données des adhérents.", 'dame' ); ?></p>
+
+					<form method="post" action="" style="display: inline-block; margin-right: 10px;">
+						<?php wp_nonce_field( 'dame_export_csv_nonce_action', 'dame_export_csv_nonce' ); ?>
+						<input type="hidden" name="dame_export_csv_action" value="1">
+						<?php submit_button( __( 'Télécharger un export CSV', 'dame' ), 'secondary', 'submit', false ); ?>
+					</form>
+
+					<form method="post" action="" style="display: inline-block;">
+						<?php wp_nonce_field( 'dame_export_nonce_action', 'dame_export_nonce' ); ?>
+						<input type="hidden" name="dame_export_action" value="1">
+						<?php submit_button( __( 'Télécharger une sauvegarde complète (.json.gz)', 'dame' ), 'primary', 'submit', false ); ?>
+					</form>
+				</div>
+
+				<div class="dame-import-section" style="padding: 15px; background: #fff; border: 1px solid #ccd0d4; box-shadow: 0 1px 1px rgba(0,0,0,.04); border-left: 4px solid #dc3232;">
+					<h2><?php esc_html_e( 'Restaurer ou Importer des données', 'dame' ); ?></h2>
+
+					<div style="margin-bottom: 20px; padding-bottom: 20px; border-bottom: 1px solid #eee;">
+						<h3><?php esc_html_e( 'Import partiel (CSV)', 'dame' ); ?></h3>
+						<p><?php esc_html_e( "L'import CSV permet d'ajouter ou de mettre à jour des adhérents.", 'dame' ); ?></p>
+						<form method="post" enctype="multipart/form-data" id="dame-import-csv-form" action="">
+							<?php wp_nonce_field( 'dame_import_csv_nonce_action', 'dame_import_csv_nonce' ); ?>
+							<p>
+								<label for="dame_import_csv_file"><strong><?php esc_html_e( 'Fichier CSV :', 'dame' ); ?></strong></label><br>
+								<input type="file" id="dame_import_csv_file" name="dame_import_csv_file" accept=".csv" required>
+							</p>
+							<?php submit_button( __( 'Importer le fichier CSV', 'dame' ), 'secondary', 'dame_import_csv_action' ); ?>
+						</form>
+					</div>
+
+					<div>
+						<h3><?php esc_html_e( 'Restauration complète (.json.gz)', 'dame' ); ?></h3>
+						<p style="color: #dc3232;"><strong><?php esc_html_e( "Attention : la restauration d'une sauvegarde complète effacera et remplacera toutes les données actuelles (Adhérents, Pré-inscriptions, Historique des messages).", 'dame' ); ?></strong></p>
+						<form method="post" enctype="multipart/form-data" id="dame-import-form" action="">
+							<?php wp_nonce_field( 'dame_import_nonce_action', 'dame_import_nonce' ); ?>
+							<p>
+								<label for="dame_import_file"><strong><?php esc_html_e( 'Fichier de sauvegarde :', 'dame' ); ?></strong></label><br>
+								<input type="file" id="dame_import_file" name="dame_import_file" accept=".gz" required>
+							</p>
+							<?php submit_button( __( 'Restaurer la base de données', 'dame' ), 'delete', 'dame_import' ); ?>
+						</form>
+					</div>
+				</div>
+			</div>
+
+			<script>
+				document.addEventListener('DOMContentLoaded', function() {
+					const importForm = document.getElementById('dame-import-form');
+					if (importForm) {
+						importForm.addEventListener('submit', function(e) {
+							if (!confirm("<?php echo esc_js( __( 'Êtes-vous sûr de vouloir restaurer cette sauvegarde ? Toutes les données d\\'adhérents existantes seront supprimées et remplacées. Cette action est irréversible.', 'dame' ) ); ?>")) {
+								e.preventDefault();
+							}
+						});
+					}
+					const importCsvForm = document.getElementById('dame-import-csv-form');
+					if (importCsvForm) {
+						importCsvForm.addEventListener('submit', function(e) {
+							if (!confirm("<?php echo esc_js( __( 'Êtes-vous sûr de vouloir importer ce fichier CSV ?', 'dame' ) ); ?>")) {
+								e.preventDefault();
+							}
+						});
+					}
+				});
+			</script>
+		</div>
+		<?php
+	}
+}

--- a/includes/Admin/Pages/BackupAgenda.php
+++ b/includes/Admin/Pages/BackupAgenda.php
@@ -53,7 +53,7 @@ class BackupAgenda {
 					const restoreForm = document.getElementById('dame-agenda-restore-form');
 					if (restoreForm) {
 						restoreForm.addEventListener('submit', function(e) {
-							if (!confirm("<?php echo esc_js( __( 'Êtes-vous sûr de vouloir restaurer cette sauvegarde ? Tous les événements et catégories existants seront supprimés et remplacés. Cette action est irréversible.', 'dame' ) ); ?>")) {
+							if (!confirm("<?php echo esc_js( __( "Êtes-vous sûr de vouloir restaurer cette sauvegarde ? Tous les événements et catégories existants seront supprimés et remplacés. Cette action est irréversible.", 'dame' ) ); ?>")) {
 								e.preventDefault();
 							}
 						});

--- a/includes/Admin/Pages/BackupAgenda.php
+++ b/includes/Admin/Pages/BackupAgenda.php
@@ -1,0 +1,66 @@
+<?php
+namespace DAME\Admin\Pages;
+
+class BackupAgenda {
+
+	public function init() {
+		add_action( 'admin_menu', [ $this, 'add_menu_page' ] );
+	}
+
+	public function add_menu_page() {
+		add_submenu_page(
+			'edit.php?post_type=dame_agenda',
+			__( 'Sauvegarde / Restauration', 'dame' ),
+			__( 'Sauvegarde / Restauration', 'dame' ),
+			'manage_options',
+			'dame-backup-agenda',
+			[ $this, 'render' ]
+		);
+	}
+
+	public function render() {
+		?>
+		<div class="wrap">
+			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+
+			<div class="dame-backup-restore-wrapper">
+				<div class="dame-backup-section" style="margin-bottom: 2em; padding: 15px; background: #fff; border: 1px solid #ccd0d4; box-shadow: 0 1px 1px rgba(0,0,0,.04);">
+					<h2><?php esc_html_e( "Sauvegarder les données de l'agenda", 'dame' ); ?></h2>
+					<p><?php esc_html_e( "Cliquez sur le bouton ci-dessous pour télécharger une sauvegarde de tous les événements et catégories de l'agenda.", 'dame' ); ?></p>
+					<form method="post" action="">
+						<?php wp_nonce_field( 'dame_agenda_backup_nonce_action', 'dame_agenda_backup_nonce' ); ?>
+						<input type="hidden" name="dame_agenda_backup_action" value="1">
+						<?php submit_button( __( 'Télécharger la sauvegarde de l\'agenda (.json.gz)', 'dame' ), 'primary', 'submit', false ); ?>
+					</form>
+				</div>
+
+				<div class="dame-restore-section" style="padding: 15px; background: #fff; border: 1px solid #ccd0d4; box-shadow: 0 1px 1px rgba(0,0,0,.04); border-left: 4px solid #dc3232;">
+					<h2><?php esc_html_e( "Restaurer les données de l'agenda", 'dame' ); ?></h2>
+					<p style="color: #dc3232;"><strong><?php esc_html_e( "Attention : la restauration d'une sauvegarde effacera et remplacera tous les événements actuels de l'agenda.", 'dame' ); ?></strong></p>
+					<form method="post" enctype="multipart/form-data" id="dame-agenda-restore-form" action="">
+						<?php wp_nonce_field( 'dame_agenda_restore_nonce_action', 'dame_agenda_restore_nonce' ); ?>
+						<p>
+							<label for="dame_agenda_restore_file"><strong><?php esc_html_e( 'Fichier de sauvegarde (.json.gz) :', 'dame' ); ?></strong></label><br>
+							<input type="file" id="dame_agenda_restore_file" name="dame_agenda_restore_file" accept=".gz" required>
+						</p>
+						<?php submit_button( __( 'Restaurer la base de données de l\'agenda', 'dame' ), 'delete', 'dame_agenda_restore_action' ); ?>
+					</form>
+				</div>
+			</div>
+
+			<script>
+				document.addEventListener('DOMContentLoaded', function() {
+					const restoreForm = document.getElementById('dame-agenda-restore-form');
+					if (restoreForm) {
+						restoreForm.addEventListener('submit', function(e) {
+							if (!confirm("<?php echo esc_js( __( 'Êtes-vous sûr de vouloir restaurer cette sauvegarde ? Tous les événements et catégories existants seront supprimés et remplacés. Cette action est irréversible.', 'dame' ) ); ?>")) {
+								e.preventDefault();
+							}
+						});
+					}
+				});
+			</script>
+		</div>
+		<?php
+	}
+}

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -234,6 +234,13 @@ class Plugin {
 			// Initialize User Assignment Page
 			$user_assignment = new UserAssignment();
 			$user_assignment->init();
+
+			// Initialisation des pages de sauvegardes manuelles
+			$backup_adherent_page = new \DAME\Admin\Pages\BackupAdherent();
+			$backup_adherent_page->init();
+
+			$backup_agenda_page = new \DAME\Admin\Pages\BackupAgenda();
+			$backup_agenda_page->init();
 		}
 	}
 }

--- a/includes/Services/Backup.php
+++ b/includes/Services/Backup.php
@@ -554,7 +554,24 @@ class Backup {
 			$terms = get_terms( [ 'taxonomy' => $tax, 'hide_empty' => false ] );
 			if ( ! is_wp_error( $terms ) ) {
 				foreach ( $terms as $term ) {
-					$data['taxonomy_terms'][ $tax ][] = [ 'old_id' => $term->term_id, 'name' => $term->name, 'slug' => $term->slug, 'description' => $term->description ];
+					$term_data = [ 'old_id' => $term->term_id, 'name' => $term->name, 'slug' => $term->slug, 'description' => $term->description ];
+
+					// Export term meta, specifically for groups
+					$term_meta = get_term_meta( $term->term_id );
+					if ( ! empty( $term_meta ) ) {
+						$term_data['meta_data'] = [];
+						foreach ( $term_meta as $k => $v ) {
+							$term_data['meta_data'][ $k ] = maybe_unserialize( $v[0] );
+						}
+					} else if ( $tax === 'dame_group' ) {
+						// Fallback if not using term_meta directly in legacy, but a custom option taxonomy_termId
+						$group_type = get_term_meta( $term->term_id, '_dame_group_type', true );
+						if ( ! empty( $group_type ) ) {
+							$term_data['meta_data'] = [ '_dame_group_type' => $group_type ];
+						}
+					}
+
+					$data['taxonomy_terms'][ $tax ][] = $term_data;
 				}
 			}
 		}
@@ -573,8 +590,42 @@ class Backup {
 			$data['adherents'][] = [ 'old_id' => $post->ID, 'post_title' => $post->post_title, 'meta_data' => $meta, 'taxonomies' => $taxs ];
 		}
 
-		// Pre-inscriptions & Messages (Same logic...)
-		// ... (Omitted for brevity, assume legacy logic is applied here)
+		// Options
+		$current_season_tag_id = get_option( 'dame_current_season_tag_id' );
+		if ( $current_season_tag_id ) {
+			$term = get_term( $current_season_tag_id );
+			if ( $term && ! is_wp_error( $term ) ) {
+				$data['options']['dame_current_season_tag_slug'] = $term->slug;
+			}
+		}
+
+		// Pre-inscriptions
+		$query = new WP_Query( [ 'post_type' => 'dame_pre_inscription', 'posts_per_page' => -1, 'post_status' => 'any' ] );
+		foreach ( $query->posts as $post ) {
+			$meta = [];
+			foreach ( get_post_meta( $post->ID ) as $k => $v ) {
+				if ( strpos( $k, '_dame_' ) === 0 ) $meta[ $k ] = maybe_unserialize( $v[0] );
+			}
+			$data['pre_inscriptions'][] = [ 'old_id' => $post->ID, 'post_title' => $post->post_title, 'meta_data' => $meta ];
+		}
+
+		// Messages
+		$query = new WP_Query( [ 'post_type' => 'dame_message', 'posts_per_page' => -1, 'post_status' => 'any' ] );
+		foreach ( $query->posts as $post ) {
+			$meta = [];
+			foreach ( get_post_meta( $post->ID ) as $k => $v ) {
+				if ( strpos( $k, '_dame_' ) === 0 ) $meta[ $k ] = maybe_unserialize( $v[0] );
+			}
+			$data['messages'][] = [ 'old_id' => $post->ID, 'post_title' => $post->post_title, 'post_content' => $post->post_content, 'post_status' => $post->post_status, 'meta_data' => $meta ];
+		}
+
+		// Message opens
+		global $wpdb;
+		$table_name = $wpdb->prefix . 'dame_message_opens';
+		$open_stats_data = $wpdb->get_results( "SELECT message_id, email_hash, opened_at, user_ip FROM {$table_name}", ARRAY_A );
+		if ( is_array( $open_stats_data ) ) {
+			$data['message_opens'] = $open_stats_data;
+		}
 
 		return $data;
 	}
@@ -616,7 +667,17 @@ class Backup {
 		foreach ( $data['taxonomy_terms'] ?? [] as $tax => $terms ) {
 			foreach ( $terms as $t ) {
 				$new = wp_insert_term( $t['name'], $tax, [ 'slug' => $t['slug'], 'description' => $t['description'] ] );
-				if ( ! is_wp_error( $new ) ) $map_terms[ $t['old_id'] ?? $t['slug'] ] = $new['term_id'];
+				if ( ! is_wp_error( $new ) ) {
+					$new_term_id = $new['term_id'];
+					$map_terms[ $t['old_id'] ?? $t['slug'] ] = $new_term_id;
+
+					// Import term metadata, restoring Group types
+					if ( ! empty( $t['meta_data'] ) ) {
+						foreach ( $t['meta_data'] as $k => $v ) {
+							update_term_meta( $new_term_id, $k, $v );
+						}
+					}
+				}
 			}
 		}
 
@@ -630,10 +691,62 @@ class Backup {
 			}
 		}
 
-		// Pre-Inscriptions, Messages, Opens... (Similar logic with remapping)
-		// ...
+		// Options
+		if ( ! empty( $data['options']['dame_current_season_tag_slug'] ) ) {
+			$term = get_term_by( 'slug', $data['options']['dame_current_season_tag_slug'], 'dame_saison_adhesion' );
+			if ( $term && ! is_wp_error( $term ) ) {
+				update_option( 'dame_current_season_tag_id', $term->term_id );
+			}
+		}
 
-		// TODO: Restore upgrade logic if needed: dame_perform_upgrade(...)
+		// Pre-inscriptions
+		foreach ( $data['pre_inscriptions'] ?? [] as $pi ) {
+			$pid = wp_insert_post( [ 'post_title' => $pi['post_title'], 'post_type' => 'dame_pre_inscription', 'post_status' => 'pending' ] );
+			if ( $pid ) {
+				foreach ( $pi['meta_data'] as $k => $v ) update_post_meta( $pid, $k, $v );
+			}
+		}
+
+		// Messages
+		foreach ( $data['messages'] ?? [] as $m ) {
+			// Sanitize input to match original code
+			$post_title = sanitize_text_field( $m['post_title'] );
+			$post_content = wp_kses_post( $m['post_content'] );
+			$post_status = sanitize_key( $m['post_status'] );
+
+			$pid = wp_insert_post( [ 'post_title' => $post_title, 'post_content' => $post_content, 'post_type' => 'dame_message', 'post_status' => $post_status ] );
+			if ( $pid ) {
+				$map_messages[ $m['old_id'] ] = $pid;
+				foreach ( $m['meta_data'] as $k => $v ) {
+					$remapped_value = $v;
+					if ( '_dame_manual_recipients' === $k && is_array( $v ) ) {
+						$remapped_value = [];
+						foreach ( $v as $old_id ) if ( isset( $map_adherents[ $old_id ] ) ) $remapped_value[] = $map_adherents[ $old_id ];
+					}
+					if ( in_array( $k, [ '_dame_recipient_seasons', '_dame_recipient_groups_saisonnier', '_dame_recipient_groups_permanent' ] ) && is_array( $v ) ) {
+						$remapped_value = [];
+						foreach ( $v as $old_id ) if ( isset( $map_terms[ $old_id ] ) ) $remapped_value[] = $map_terms[ $old_id ];
+					}
+					update_post_meta( $pid, $k, $remapped_value );
+				}
+			}
+		}
+
+		// Message opens
+		foreach ( $data['message_opens'] ?? [] as $mo ) {
+			if ( isset( $map_messages[ $mo['message_id'] ] ) ) {
+				$wpdb->insert(
+					"{$wpdb->prefix}dame_message_opens",
+					[ 'message_id' => $map_messages[ $mo['message_id'] ], 'email_hash' => $mo['email_hash'], 'opened_at' => $mo['opened_at'], 'user_ip' => $mo['user_ip'] ],
+					[ '%d', '%s', '%s', '%s' ]
+				);
+			}
+		}
+
+		$imported_version = $data['version'] ?? '2.2.0';
+		if ( function_exists( 'dame_perform_upgrade' ) ) {
+			dame_perform_upgrade( $imported_version, DAME_VERSION );
+		}
 
 		$this->add_admin_notice( "Import terminé avec succès." );
 	}

--- a/includes/Services/Backup.php
+++ b/includes/Services/Backup.php
@@ -17,6 +17,27 @@ class Backup {
 	public function init() {
 		// Handle manual export/import actions (triggered via admin POST).
 		add_action( 'admin_init', [ $this, 'handle_manual_actions' ] );
+		add_action( 'admin_notices', [ $this, 'display_import_export_notices' ] );
+	}
+
+	/**
+	 * Adds an admin notice to be displayed on the next page load.
+	 */
+	private function add_admin_notice( $message, $type = 'success' ) {
+		set_transient( 'dame_import_export_notice', array( 'message' => $message, 'type' => $type ), 30 );
+	}
+
+	/**
+	 * Displays the admin notice if one is set.
+	 */
+	public function display_import_export_notices() {
+		if ( get_transient( 'dame_import_export_notice' ) ) {
+			$notice = get_transient( 'dame_import_export_notice' );
+			$message = $notice['message'];
+			$type = $notice['type'];
+			echo '<div class="notice notice-' . esc_attr( $type ) . ' is-dismissible"><p>' . wp_kses_post( $message ) . '</p></div>';
+			delete_transient( 'dame_import_export_notice' );
+		}
 	}
 
 	/**
@@ -203,7 +224,7 @@ class Backup {
 
 	private function import_csv_adherents() {
 		if ( ! isset( $_FILES['dame_import_csv_file'] ) || $_FILES['dame_import_csv_file']['error'] !== UPLOAD_ERR_OK ) {
-			dame_add_admin_notice( __( 'Erreur lors du téléversement du fichier.', 'dame' ), 'error' );
+			$this->add_admin_notice( __( 'Erreur lors du téléversement du fichier.', 'dame' ), 'error' );
 			return;
 		}
 
@@ -211,7 +232,7 @@ class Backup {
 		$mime_type = mime_content_type( $file['tmp_name'] );
 
 		if ( 'text/plain' !== $mime_type && 'text/csv' !== $mime_type ) {
-			dame_add_admin_notice( __( 'Le fichier téléversé n\'est pas un fichier CSV valide.', 'dame' ), 'error' );
+			$this->add_admin_notice( __( 'Le fichier téléversé n\'est pas un fichier CSV valide.', 'dame' ), 'error' );
 			return;
 		}
 
@@ -220,14 +241,14 @@ class Backup {
 
 		$handle = fopen( $file['tmp_name'], 'r' );
 		if ( false === $handle ) {
-			dame_add_admin_notice( __( 'Impossible d\'ouvrir le fichier téléversé.', 'dame' ), 'error' );
+			$this->add_admin_notice( __( 'Impossible d\'ouvrir le fichier téléversé.', 'dame' ), 'error' );
 			return;
 		}
 
 		// Read header row and map columns
 		$header = fgetcsv( $handle, 0, ';' );
 		if ( false === $header ) {
-			dame_add_admin_notice( __( 'Impossible de lire l\'en-tête du fichier CSV.', 'dame' ), 'error' );
+			$this->add_admin_notice( __( 'Impossible de lire l\'en-tête du fichier CSV.', 'dame' ), 'error' );
 			fclose( $handle );
 			return;
 		}
@@ -515,7 +536,7 @@ class Backup {
 			),
 			$imported_count
 		);
-		dame_add_admin_notice( $message );
+		$this->add_admin_notice( $message );
 	}
 
 	/* -------------------------------------------------------------------------
@@ -614,7 +635,7 @@ class Backup {
 
 		// TODO: Restore upgrade logic if needed: dame_perform_upgrade(...)
 
-		dame_add_admin_notice( "Import terminé avec succès." );
+		$this->add_admin_notice( "Import terminé avec succès." );
 	}
 
 	/* -------------------------------------------------------------------------
@@ -678,7 +699,7 @@ class Backup {
 				if ( ! empty( $e['categories'] ) ) wp_set_object_terms( $pid, $e['categories'], 'dame_agenda_category' );
 			}
 		}
-		dame_add_admin_notice( "Agenda restauré avec succès." );
+		$this->add_admin_notice( "Agenda restauré avec succès." );
 	}
 
 	/* -------------------------------------------------------------------------

--- a/includes/Services/Backup.php
+++ b/includes/Services/Backup.php
@@ -717,17 +717,19 @@ class Backup {
 			$pid = wp_insert_post( [ 'post_title' => $post_title, 'post_content' => $post_content, 'post_type' => 'dame_message', 'post_status' => $post_status ] );
 			if ( $pid ) {
 				$map_messages[ $m['old_id'] ] = $pid;
-				foreach ( $m['meta_data'] as $k => $v ) {
-					$remapped_value = $v;
-					if ( '_dame_manual_recipients' === $k && is_array( $v ) ) {
-						$remapped_value = [];
-						foreach ( $v as $old_id ) if ( isset( $map_adherents[ $old_id ] ) ) $remapped_value[] = $map_adherents[ $old_id ];
+				if ( isset( $m['meta_data'] ) && is_array( $m['meta_data'] ) ) {
+					foreach ( $m['meta_data'] as $k => $v ) {
+						$remapped_value = $v;
+						if ( '_dame_manual_recipients' === $k && is_array( $v ) ) {
+							$remapped_value = [];
+							foreach ( $v as $old_id ) if ( isset( $map_adherents[ $old_id ] ) ) $remapped_value[] = $map_adherents[ $old_id ];
+						}
+						if ( in_array( $k, [ '_dame_recipient_seasons', '_dame_recipient_groups_saisonnier', '_dame_recipient_groups_permanent' ] ) && is_array( $v ) ) {
+							$remapped_value = [];
+							foreach ( $v as $old_id ) if ( isset( $map_terms[ $old_id ] ) ) $remapped_value[] = $map_terms[ $old_id ];
+						}
+						update_post_meta( $pid, $k, $remapped_value );
 					}
-					if ( in_array( $k, [ '_dame_recipient_seasons', '_dame_recipient_groups_saisonnier', '_dame_recipient_groups_permanent' ] ) && is_array( $v ) ) {
-						$remapped_value = [];
-						foreach ( $v as $old_id ) if ( isset( $map_terms[ $old_id ] ) ) $remapped_value[] = $map_terms[ $old_id ];
-					}
-					update_post_meta( $pid, $k, $remapped_value );
 				}
 			}
 		}

--- a/includes/Services/Backup.php
+++ b/includes/Services/Backup.php
@@ -70,10 +70,174 @@ class Backup {
 		header( 'Content-Disposition: attachment; filename=' . $filename );
 
 		$output = fopen( 'php://output', 'w' );
-		fprintf( $output, chr( 0xEF ) . chr( 0xBB ) . chr( 0xBF ) ); // BOM
 
-		// Headers
-		$headers = [
+		// Add BOM to fix UTF-8 in Excel.
+		fprintf( $output, chr( 0xEF ) . chr( 0xBB ) . chr( 0xBF ) );
+
+		// --- Dynamic Headers ---
+		// 1. Get all seasons and sort them.
+		$all_seasons = get_terms(
+			array(
+				'taxonomy'   => 'dame_saison_adhesion',
+				'hide_empty' => false,
+				'orderby'    => 'name',
+				'order'      => 'DESC',
+			)
+		);
+
+		// 2. Build the header array.
+		$headers = array(
+			__( 'Nom de naissance', 'dame' ), __( 'Nom d\'usage', 'dame' ), __( 'Prénom', 'dame' ), __( 'Date de naissance', 'dame' ), __( 'Lieu de naissance', 'dame' ), __( 'Sexe', 'dame' ), __( 'Profession', 'dame' ), __( 'Adresse email', 'dame' ), __( 'Numéro de téléphone', 'dame' ),
+			__( 'Adresse', 'dame' ), __( 'Complément', 'dame' ), __( 'Code Postal', 'dame' ), __( 'Ville', 'dame' ), __( 'Pays', 'dame' ), __( 'Numéro de licence', 'dame' ),
+			__( 'Type de licence', 'dame' ), __( 'Ecole d\'échecs (O/N)', 'dame' ), __( 'Pôle excellence (O/N)', 'dame' ), __( 'Bénévole (O/N)', 'dame' ), __( 'Elu local (O/N)', 'dame' ), __( 'Arbitre', 'dame' ),
+			__( 'Représentant légal 1 - Nom de naissance', 'dame' ), __( 'Représentant légal 1 - Prénom', 'dame' ), __( 'Représentant légal 1 - Profession', 'dame' ), __( 'Représentant légal 1 - Email', 'dame' ), __( 'Représentant légal 1 - Téléphone', 'dame' ),
+			__( 'Représentant légal 1 - Adresse', 'dame' ), __( 'Représentant légal 1 - Complément', 'dame' ), __( 'Représentant légal 1 - Code Postal', 'dame' ), __( 'Représentant légal 1 - Ville', 'dame' ),
+			__( 'Représentant légal 2 - Nom de naissance', 'dame' ), __( 'Représentant légal 2 - Prénom', 'dame' ), __( 'Représentant légal 2 - Profession', 'dame' ), __( 'Représentant légal 2 - Email', 'dame' ), __( 'Représentant légal 2 - Téléphone', 'dame' ),
+			__( 'Représentant légal 2 - Adresse', 'dame' ), __( 'Représentant légal 2 - Complément', 'dame' ), __( 'Représentant légal 2 - Code Postal', 'dame' ), __( 'Représentant légal 2 - Ville', 'dame' ),
+			__( 'Autre téléphone', 'dame' ), __( 'Taille vêtements', 'dame' ), __( 'Allergies', 'dame' ), __( 'Régime alimentaire', 'dame' ), __( 'Moyen de locomotion', 'dame' ),
+		);
+
+		// 3. Add dynamic season headers.
+		if ( ! is_wp_error( $all_seasons ) ) {
+			foreach ( $all_seasons as $season ) {
+				$headers[] = sprintf( __( 'Adhérent %s', 'dame' ), $season->name );
+			}
+		}
+
+		fputcsv( $output, $headers, ';' );
+
+		// --- Dynamic Rows ---
+		$adherents_query = new WP_Query(
+			array(
+				'post_type'      => 'adherent',
+				'posts_per_page' => -1,
+				'post_status'    => 'any',
+				'orderby'        => 'title',
+				'order'          => 'ASC',
+			)
+		);
+
+		if ( $adherents_query->have_posts() ) {
+			while ( $adherents_query->have_posts() ) {
+				$adherents_query->the_post();
+				$post_id = get_the_ID();
+
+				// Get adherent's seasons
+				$adherent_seasons_slugs = wp_get_post_terms( $post_id, 'dame_saison_adhesion', array( 'fields' => 'slugs' ) );
+				if ( is_wp_error( $adherent_seasons_slugs ) ) {
+					$adherent_seasons_slugs = array();
+				}
+
+				// Format dates.
+				$birth_date             = get_post_meta( $post_id, '_dame_birth_date', true );
+				$formatted_birth_date   = $birth_date ? date( 'd/m/Y', strtotime( $birth_date ) ) : '';
+
+				// Format booleans.
+				$is_ecole_echecs    = get_post_meta( $post_id, '_dame_is_junior', true ) ? 'O' : 'N';
+				$is_pole_excellence = get_post_meta( $post_id, '_dame_is_pole_excellence', true ) ? 'O' : 'N';
+				$is_benevole        = get_post_meta( $post_id, '_dame_is_benevole', true ) ? 'O' : 'N';
+				$is_elu_local       = get_post_meta( $post_id, '_dame_is_elu_local', true ) ? 'O' : 'N';
+
+				$row = array(
+					get_post_meta( $post_id, '_dame_birth_name', true ),
+					get_post_meta( $post_id, '_dame_last_name', true ),
+					get_post_meta( $post_id, '_dame_first_name', true ),
+					$formatted_birth_date,
+					get_post_meta( $post_id, '_dame_birth_city', true ),
+					get_post_meta( $post_id, '_dame_sexe', true ),
+					get_post_meta( $post_id, '_dame_profession', true ),
+					get_post_meta( $post_id, '_dame_email', true ),
+					get_post_meta( $post_id, '_dame_phone_number', true ),
+					get_post_meta( $post_id, '_dame_address_1', true ),
+					get_post_meta( $post_id, '_dame_address_2', true ),
+					get_post_meta( $post_id, '_dame_postal_code', true ),
+					get_post_meta( $post_id, '_dame_city', true ),
+					get_post_meta( $post_id, '_dame_country', true ),
+					get_post_meta( $post_id, '_dame_license_number', true ),
+					get_post_meta( $post_id, '_dame_license_type', true ),
+					$is_ecole_echecs,
+					$is_pole_excellence,
+					$is_benevole,
+					$is_elu_local,
+					get_post_meta( $post_id, '_dame_arbitre_level', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_1_last_name', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_1_first_name', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_1_profession', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_1_email', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_1_phone', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_1_address_1', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_1_address_2', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_1_postal_code', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_1_city', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_2_last_name', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_2_first_name', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_2_profession', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_2_email', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_2_phone', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_2_address_1', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_2_address_2', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_2_postal_code', true ),
+					get_post_meta( $post_id, '_dame_legal_rep_2_city', true ),
+					get_post_meta( $post_id, '_dame_autre_telephone', true ),
+					get_post_meta( $post_id, '_dame_taille_vetements', true ),
+					get_post_meta( $post_id, '_dame_allergies', true ),
+					get_post_meta( $post_id, '_dame_diet', true ),
+					get_post_meta( $post_id, '_dame_transport', true ),
+				);
+
+				// Add dynamic season data
+				if ( ! is_wp_error( $all_seasons ) ) {
+					foreach ( $all_seasons as $season ) {
+						$row[] = in_array( $season->slug, $adherent_seasons_slugs, true ) ? 'O' : 'N';
+					}
+				}
+
+				fputcsv( $output, $row, ';' );
+			}
+			wp_reset_postdata();
+		}
+
+		fclose( $output );
+		exit;
+	}
+
+	private function import_csv_adherents() {
+		if ( ! isset( $_FILES['dame_import_csv_file'] ) || $_FILES['dame_import_csv_file']['error'] !== UPLOAD_ERR_OK ) {
+			dame_add_admin_notice( __( 'Erreur lors du téléversement du fichier.', 'dame' ), 'error' );
+			return;
+		}
+
+		$file = $_FILES['dame_import_csv_file'];
+		$mime_type = mime_content_type( $file['tmp_name'] );
+
+		if ( 'text/plain' !== $mime_type && 'text/csv' !== $mime_type ) {
+			dame_add_admin_notice( __( 'Le fichier téléversé n\'est pas un fichier CSV valide.', 'dame' ), 'error' );
+			return;
+		}
+
+		// Increase execution time
+		set_time_limit( 300 );
+
+		$handle = fopen( $file['tmp_name'], 'r' );
+		if ( false === $handle ) {
+			dame_add_admin_notice( __( 'Impossible d\'ouvrir le fichier téléversé.', 'dame' ), 'error' );
+			return;
+		}
+
+		// Read header row and map columns
+		$header = fgetcsv( $handle, 0, ';' );
+		if ( false === $header ) {
+			dame_add_admin_notice( __( 'Impossible de lire l\'en-tête du fichier CSV.', 'dame' ), 'error' );
+			fclose( $handle );
+			return;
+		}
+
+		// Remove BOM from the first header element if present
+		if ( isset( $header[0] ) ) {
+			$header[0] = preg_replace( '/^\x{FEFF}/u', '', $header[0] );
+		}
+
+		$expected_headers = array(
 			'Nom de naissance', 'Nom d\'usage', 'Prénom', 'Date de naissance', 'Lieu de naissance', 'Sexe', 'Profession', 'Adresse email', 'Numéro de téléphone',
 			'Adresse', 'Complément', 'Code Postal', 'Ville', 'Pays', 'Numéro de licence', 'Type de licence', 'Ecole d\'échecs (O/N)', 'Pôle excellence (O/N)', 'Bénévole (O/N)', 'Elu local (O/N)', 'Arbitre',
 			'Représentant légal 1 - Nom de naissance', 'Représentant légal 1 - Prénom', 'Représentant légal 1 - Profession', 'Représentant légal 1 - Email', 'Représentant légal 1 - Téléphone',
@@ -81,77 +245,277 @@ class Backup {
 			'Représentant légal 2 - Nom de naissance', 'Représentant légal 2 - Prénom', 'Représentant légal 2 - Profession', 'Représentant légal 2 - Email', 'Représentant légal 2 - Téléphone',
 			'Représentant légal 2 - Adresse', 'Représentant légal 2 - Complément', 'Représentant légal 2 - Code Postal', 'Représentant légal 2 - Ville',
 			'Autre téléphone', 'Taille vêtements', 'Allergies', 'Régime alimentaire', 'Moyen de locomotion'
-		];
+		);
+		$col_map = array_flip( $header );
 
-		$all_seasons = get_terms( [ 'taxonomy' => 'dame_saison_adhesion', 'hide_empty' => false, 'orderby' => 'name', 'order' => 'DESC' ] );
-		if ( ! is_wp_error( $all_seasons ) ) {
-			foreach ( $all_seasons as $season ) {
-				$headers[] = 'Adhérent ' . $season->name;
-			}
-		}
+		// Data mapping from CSV columns to post meta keys
+		$meta_mapping = array(
+			'Nom de naissance' => '_dame_birth_name',
+			'Nom d\'usage' => '_dame_last_name',
+			'Prénom' => '_dame_first_name',
+			'Date de naissance' => '_dame_birth_date',
+			'Lieu de naissance' => '_dame_birth_city',
+			'Sexe' => '_dame_sexe',
+			'Profession' => '_dame_profession',
+			'Adresse email' => '_dame_email',
+			'Numéro de téléphone' => '_dame_phone_number',
+			'Adresse' => '_dame_address_1',
+			'Complément' => '_dame_address_2',
+			'Code Postal' => '_dame_postal_code',
+			'Ville' => '_dame_city',
+			'Pays' => '_dame_country',
+			'Numéro de licence' => '_dame_license_number',
+			'Type de licence' => '_dame_license_type',
+			'Ecole d\'échecs (O/N)' => '_dame_is_junior',
+			'Pôle excellence (O/N)' => '_dame_is_pole_excellence',
+			'Bénévole (O/N)' => '_dame_is_benevole',
+			'Elu local (O/N)' => '_dame_is_elu_local',
+			'Arbitre' => '_dame_arbitre_level',
+			'Représentant légal 1 - Nom de naissance' => '_dame_legal_rep_1_last_name',
+			'Représentant légal 1 - Prénom' => '_dame_legal_rep_1_first_name',
+			'Représentant légal 1 - Profession' => '_dame_legal_rep_1_profession',
+			'Représentant légal 1 - Email' => '_dame_legal_rep_1_email',
+			'Représentant légal 1 - Téléphone' => '_dame_legal_rep_1_phone',
+			'Représentant légal 1 - Adresse' => '_dame_legal_rep_1_address_1',
+			'Représentant légal 1 - Complément' => '_dame_legal_rep_1_address_2',
+			'Représentant légal 1 - Code Postal' => '_dame_legal_rep_1_postal_code',
+			'Représentant légal 1 - Ville' => '_dame_legal_rep_1_city',
+			'Représentant légal 2 - Nom de naissance' => '_dame_legal_rep_2_last_name',
+			'Représentant légal 2 - Prénom' => '_dame_legal_rep_2_first_name',
+			'Représentant légal 2 - Profession' => '_dame_legal_rep_2_profession',
+			'Représentant légal 2 - Email' => '_dame_legal_rep_2_email',
+			'Représentant légal 2 - Téléphone' => '_dame_legal_rep_2_phone',
+			'Représentant légal 2 - Adresse' => '_dame_legal_rep_2_address_1',
+			'Représentant légal 2 - Complément' => '_dame_legal_rep_2_address_2',
+			'Représentant légal 2 - Code Postal' => '_dame_legal_rep_2_postal_code',
+			'Représentant légal 2 - Ville' => '_dame_legal_rep_2_city',
+			'Autre téléphone' => '_dame_autre_telephone',
+			'Taille vêtements' => '_dame_taille_vetements',
+			'Allergies' => '_dame_allergies',
+			'Régime alimentaire' => '_dame_diet',
+			'Moyen de locomotion' => '_dame_transport',
+		);
 
-		fputcsv( $output, $headers, ';' );
+		$imported_count = 0;
+		$department_region_mapping = dame_get_department_region_mapping();
+		$all_seasons = get_terms( [ 'taxonomy' => 'dame_saison_adhesion', 'hide_empty' => false ] );
 
-		// Rows
-		$query = new WP_Query( [ 'post_type' => 'adherent', 'posts_per_page' => -1, 'post_status' => 'any', 'orderby' => 'title', 'order' => 'ASC' ] );
-		while ( $query->have_posts() ) {
-			$query->the_post();
-			$pid = get_the_ID();
-			$seasons = wp_get_post_terms( $pid, 'dame_saison_adhesion', [ 'fields' => 'slugs' ] );
-			if ( is_wp_error( $seasons ) ) $seasons = [];
-
-			$birth_date = get_post_meta( $pid, '_dame_birth_date', true );
-			$fmt_date = $birth_date ? date( 'd/m/Y', strtotime( $birth_date ) ) : '';
-
-			$row = [
-				get_post_meta( $pid, '_dame_birth_name', true ),
-				get_post_meta( $pid, '_dame_last_name', true ),
-				get_post_meta( $pid, '_dame_first_name', true ),
-				$fmt_date,
-				get_post_meta( $pid, '_dame_birth_city', true ),
-				get_post_meta( $pid, '_dame_sexe', true ),
-				get_post_meta( $pid, '_dame_profession', true ),
-				get_post_meta( $pid, '_dame_email', true ),
-				get_post_meta( $pid, '_dame_phone_number', true ),
-				get_post_meta( $pid, '_dame_address_1', true ),
-				get_post_meta( $pid, '_dame_address_2', true ),
-				get_post_meta( $pid, '_dame_postal_code', true ),
-				get_post_meta( $pid, '_dame_city', true ),
-				get_post_meta( $pid, '_dame_country', true ),
-				get_post_meta( $pid, '_dame_license_number', true ),
-				get_post_meta( $pid, '_dame_license_type', true ),
-				get_post_meta( $pid, '_dame_is_junior', true ) ? 'O' : 'N',
-				get_post_meta( $pid, '_dame_is_pole_excellence', true ) ? 'O' : 'N',
-				get_post_meta( $pid, '_dame_is_benevole', true ) ? 'O' : 'N',
-				get_post_meta( $pid, '_dame_is_elu_local', true ) ? 'O' : 'N',
-				get_post_meta( $pid, '_dame_arbitre_level', true ),
-				// Legal Reps... (Simplified for brevity, same pattern)
-				get_post_meta( $pid, '_dame_legal_rep_1_last_name', true ), get_post_meta( $pid, '_dame_legal_rep_1_first_name', true ), '', '', '', '', '', '', '',
-				get_post_meta( $pid, '_dame_legal_rep_2_last_name', true ), get_post_meta( $pid, '_dame_legal_rep_2_first_name', true ), '', '', '', '', '', '', '',
-				get_post_meta( $pid, '_dame_autre_telephone', true ),
-				get_post_meta( $pid, '_dame_taille_vetements', true ),
-				get_post_meta( $pid, '_dame_allergies', true ),
-				get_post_meta( $pid, '_dame_diet', true ),
-				get_post_meta( $pid, '_dame_transport', true ),
-			];
-
-			if ( ! is_wp_error( $all_seasons ) ) {
-				foreach ( $all_seasons as $season ) {
-					$row[] = in_array( $season->slug, $seasons, true ) ? 'O' : 'N';
+		while ( ( $row = fgetcsv( $handle, 0, ';' ) ) !== false ) {
+			$member_data = array();
+			foreach ( $expected_headers as $header_name ) {
+				$col_index = isset( $col_map[ $header_name ] ) ? $col_map[ $header_name ] : -1;
+				if ( $col_index !== -1 && isset( $row[ $col_index ] ) ) {
+					$member_data[ $header_name ] = trim( $row[ $col_index ] );
+				} else {
+					$member_data[ $header_name ] = '';
 				}
 			}
-			fputcsv( $output, $row, ';' );
-		}
-		wp_reset_postdata();
-		fclose( $output );
-		exit;
-	}
 
-	private function import_csv_adherents() {
-		// Logic similar to dame_handle_csv_import_action
-		// Checking file, looping rows, mapping columns, creating posts.
-		// NOTE: Detailed implementation skipped for brevity in this prompt,
-		// but allows standard CSV import as defined in legacy.
+			// Capture dynamic seasons if present in CSV row based on expected pattern
+			$season_data = [];
+			if ( ! is_wp_error( $all_seasons ) ) {
+				foreach ( $all_seasons as $season ) {
+					$season_header = 'Adhérent ' . $season->name;
+					$col_index = isset( $col_map[ $season_header ] ) ? $col_map[ $season_header ] : -1;
+					if ( $col_index !== -1 && isset( $row[ $col_index ] ) ) {
+						$season_data[ $season->slug ] = trim( mb_strtoupper( $row[ $col_index ], 'UTF-8' ) ) === 'O';
+					}
+				}
+			}
+
+			$first_name = $member_data['Prénom'];
+			$last_name = $member_data['Nom d\'usage'];
+
+			if ( empty( $first_name ) || empty( $last_name ) ) {
+				continue; // Skip rows without a name
+			}
+
+			$post_id = 0;
+			$email = $member_data['Adresse email'];
+			$license = $member_data['Numéro de licence'];
+			$post_title = mb_strtoupper( $last_name, 'UTF-8' ) . ' ' . $first_name;
+
+			// Reconciliation
+			$query_args = array(
+				'post_type'      => 'adherent',
+				'posts_per_page' => 1,
+				'post_status'    => 'any',
+				'fields'         => 'ids',
+			);
+
+			if ( ! empty( $license ) ) {
+				$query_args['meta_query'] = array(
+					array( 'key' => '_dame_license_number', 'value' => $license, 'compare' => '=' ),
+				);
+				$posts = get_posts( $query_args );
+				if ( ! empty( $posts ) ) $post_id = $posts[0];
+			}
+
+			if ( ! $post_id && ! empty( $email ) ) {
+				$query_args['meta_query'] = array(
+					array( 'key' => '_dame_email', 'value' => $email, 'compare' => '=' ),
+				);
+				$posts = get_posts( $query_args );
+				if ( ! empty( $posts ) ) $post_id = $posts[0];
+			}
+
+			if ( ! $post_id ) {
+				$query_args['title'] = $post_title;
+				unset( $query_args['meta_query'] );
+				$posts = get_posts( $query_args );
+				if ( ! empty( $posts ) ) $post_id = $posts[0];
+			}
+
+			if ( ! $post_id ) {
+				$post_data = array(
+					'post_title'  => $post_title,
+					'post_type'   => 'adherent',
+					'post_status' => 'publish',
+				);
+				$post_id = wp_insert_post( $post_data );
+			} else {
+				// Update title in case name changed
+				wp_update_post( array(
+					'ID'         => $post_id,
+					'post_title' => $post_title,
+				) );
+			}
+
+			if ( $post_id ) {
+				foreach ( $meta_mapping as $csv_header => $meta_key ) {
+					$value = $member_data[ $csv_header ];
+
+					if ( '_dame_birth_date' === $meta_key ) {
+						if ( ! empty( $value ) ) {
+							$date = DateTime::createFromFormat( 'd/m/Y', $value );
+							if ( $date ) {
+								$value = $date->format( 'Y-m-d' );
+							} else {
+								$value = ''; // Invalid date format
+							}
+						} else {
+							$value = '1950-09-19';
+						}
+					}
+
+					if ( '_dame_membership_status' === $meta_key ) {
+						$status_key = 'N'; // Default to 'Non Adhérent'
+						$normalized_value = mb_strtoupper( trim( $value ), 'UTF-8' );
+
+						// Handle cases like "Actif (A)" by extracting the key
+						if ( preg_match( '/\(([A-Z])\)/', $normalized_value, $matches ) ) {
+							$normalized_value = $matches[1];
+						}
+
+						$status_map = array(
+							'ACTIF' => 'A',
+							'A' => 'A',
+							'EXPIRÉ' => 'E',
+							'EXPIRE' => 'E',
+							'E' => 'E',
+							'ANCIEN' => 'X',
+							'X' => 'X',
+							'NON ADHÉRENT' => 'N',
+							'NON ADHERENT' => 'N',
+							'N' => 'N',
+						);
+
+						if ( isset( $status_map[ $normalized_value ] ) ) {
+							$status_key = $status_map[ $normalized_value ];
+						}
+						$value = $status_key;
+					}
+
+					// Sanitize phone numbers
+					if ( in_array( $meta_key, array( '_dame_phone_number', '_dame_autre_telephone' ) ) ) {
+						$phone_number = str_replace( array( ' ', '.' ), '', $value );
+						if ( substr( $phone_number, 0, 3 ) === '+33' ) {
+							$phone_number = '0' . substr( $phone_number, 3 );
+						} elseif ( substr( $phone_number, 0, 2 ) === '33' ) {
+							$phone_number = '0' . substr( $phone_number, 2 );
+						}
+						$value = $phone_number;
+					}
+
+					// Handle boolean fields (O/N)
+					$boolean_fields = [
+						'_dame_is_junior',
+						'_dame_is_pole_excellence',
+						'_dame_is_benevole',
+						'_dame_is_elu_local',
+					];
+					if ( in_array( $meta_key, $boolean_fields ) ) {
+						$value = ( mb_strtoupper( trim( $value ), 'UTF-8' ) === 'O' ) ? 1 : 0;
+					}
+
+					update_post_meta( $post_id, $meta_key, sanitize_text_field( $value ) );
+				}
+
+				// Handle postal code logic
+				$postal_code = $member_data['Code Postal'];
+				if ( ! empty( $postal_code ) ) {
+					update_post_meta( $post_id, '_dame_country', 'FR' );
+
+					$department_code = substr( $postal_code, 0, 2 );
+					if ( strlen( $postal_code ) >= 3 ) {
+						if ( strpos( $postal_code, '20' ) === 0 ) {
+							$department_code = intval( substr( $postal_code, 2, 1 ) ) <= 1 ? '2A' : '2B';
+						} elseif ( strpos( $postal_code, '97' ) === 0 ) {
+							$department_code = substr( $postal_code, 0, 3 );
+						}
+					}
+
+					update_post_meta( $post_id, '_dame_department', $department_code );
+
+					if ( isset( $department_region_mapping[ $department_code ] ) ) {
+						update_post_meta( $post_id, '_dame_region', $department_region_mapping[ $department_code ] );
+					}
+				}
+
+				// Set defaults for fields not in CSV
+				if ( empty( get_post_meta( $post_id, '_dame_license_type', true ) ) ) {
+					update_post_meta( $post_id, '_dame_license_type', 'Non précisé' );
+				}
+				if ( empty( get_post_meta( $post_id, '_dame_arbitre_level', true ) ) ) {
+					update_post_meta( $post_id, '_dame_arbitre_level', 'Non' );
+				}
+
+				// Handle Seasons
+				if ( ! empty( $season_data ) ) {
+					$current_seasons = wp_get_post_terms( $post_id, 'dame_saison_adhesion', array( 'fields' => 'slugs' ) );
+					if ( is_wp_error( $current_seasons ) ) {
+						$current_seasons = array();
+					}
+
+					foreach ( $season_data as $season_slug => $is_in_season ) {
+						if ( $is_in_season ) {
+							if ( ! in_array( $season_slug, $current_seasons, true ) ) {
+								wp_set_object_terms( $post_id, $season_slug, 'dame_saison_adhesion', true );
+							}
+						} else {
+							if ( in_array( $season_slug, $current_seasons, true ) ) {
+								wp_remove_object_terms( $post_id, $season_slug, 'dame_saison_adhesion' );
+							}
+						}
+					}
+				}
+
+				$imported_count++;
+			}
+		}
+
+		fclose( $handle );
+
+		$message = sprintf(
+			_n(
+				'%d adhérent a été importé avec succès.',
+				'%d adhérents ont été importés avec succès.',
+				$imported_count,
+				'dame'
+			),
+			$imported_count
+		);
+		dame_add_admin_notice( $message );
 	}
 
 	/* -------------------------------------------------------------------------

--- a/old-sources/admin/backup-restore-adherent.php
+++ b/old-sources/admin/backup-restore-adherent.php
@@ -408,22 +408,12 @@ function dame_get_adherent_export_data() {
         if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
             $export_data['taxonomy_terms'][ $taxonomy ] = array();
             foreach ( $terms as $term ) {
-                $term_data = array(
-                    'old_id'      => $term->term_id,
+                $export_data['taxonomy_terms'][ $taxonomy ][] = array(
+					'old_id'      => $term->term_id,
                     'name'        => $term->name,
                     'slug'        => $term->slug,
                     'description' => $term->description,
                 );
-
-                // NOUVEAU : On récupère le type de groupe pour l'exporter
-                if ( $taxonomy === 'dame_group' ) {
-                    $group_type = get_term_meta( $term->term_id, '_dame_group_type', true );
-                    if ( ! empty( $group_type ) ) {
-                        $term_data['meta_data'] = array( '_dame_group_type' => $group_type );
-                    }
-                }
-
-                $export_data['taxonomy_terms'][ $taxonomy ][] = $term_data;
             }
         }
     }

--- a/old-sources/admin/backup-restore-adherent.php
+++ b/old-sources/admin/backup-restore-adherent.php
@@ -408,12 +408,22 @@ function dame_get_adherent_export_data() {
         if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
             $export_data['taxonomy_terms'][ $taxonomy ] = array();
             foreach ( $terms as $term ) {
-                $export_data['taxonomy_terms'][ $taxonomy ][] = array(
-					'old_id'      => $term->term_id,
+                $term_data = array(
+                    'old_id'      => $term->term_id,
                     'name'        => $term->name,
                     'slug'        => $term->slug,
                     'description' => $term->description,
                 );
+
+                // NOUVEAU : On récupère le type de groupe pour l'exporter
+                if ( $taxonomy === 'dame_group' ) {
+                    $group_type = get_term_meta( $term->term_id, '_dame_group_type', true );
+                    if ( ! empty( $group_type ) ) {
+                        $term_data['meta_data'] = array( '_dame_group_type' => $group_type );
+                    }
+                }
+
+                $export_data['taxonomy_terms'][ $taxonomy ][] = $term_data;
             }
         }
     }


### PR DESCRIPTION
Fixes a backward compatibility issue where messages imported from the legacy system didn't show their original sending date, author, or recipient counts in the WP Admin list table. Implemented explicit fallbacks to check for the old metadata keys (`_dame_sent_date`, `_dame_sending_author`, and `_dame_total_recipients`) within `DAME\Admin\Columns\Message::render_columns`.

---
*PR created automatically by Jules for task [13549773484219982755](https://jules.google.com/task/13549773484219982755) started by @Trollinou*