### PR TITLE
Fix Contact Form AJAX Functionality

### DIFF
--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -38,6 +38,7 @@ use DAME\Services\Birthday;
 use DAME\Shortcodes\RegistrationForm;
 use DAME\Shortcodes\Agenda as AgendaShortcode;
 use DAME\Shortcodes\Sondage as SondageShortcode;
+use DAME\Shortcodes\Contact as ContactShortcode;
 use DAME\Admin\Assets;
 use DAME\Admin\Pages\ViewAdherent;
 use DAME\Admin\Settings\Main as SettingsMain;
@@ -151,6 +152,9 @@ class Plugin {
 
 		$sondage_shortcode = new SondageShortcode();
 		$sondage_shortcode->init();
+
+		$contact_shortcode = new ContactShortcode();
+		$contact_shortcode->init();
 
 		// Initialize Taxonomies (MUST BE GLOBAL, NOT INSIDE is_admin)
 		$season_taxonomy = new Season();

--- a/includes/Shortcodes/Contact.php
+++ b/includes/Shortcodes/Contact.php
@@ -48,6 +48,9 @@ class Contact {
 
 				<?php wp_nonce_field( 'dame_contact_nonce', 'dame_contact_nonce_field' ); ?>
 
+				<!-- Action -->
+				<input type="hidden" name="action" value="dame_submit_contact_form">
+
 				<!-- Honeypot -->
 				<div style="display:none;">
 					<label for="dame_contact_hp"><?php _e( "Laissez ce champ vide", "dame" ); ?></label>
@@ -76,8 +79,9 @@ class Contact {
 
 				<p>
 					<button type="submit"><?php _e( "Envoyer", "dame" ); ?></button>
-					<span id="dame-contact-form-messages" style="margin-left: 10px;"></span>
 				</p>
+
+				<div id="dame-contact-feedback" style="display:none;"></div>
 
 			</form>
 		</div>

--- a/includes/Shortcodes/Contact.php
+++ b/includes/Shortcodes/Contact.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Shortcode for the contact form.
+ *
+ * @package DAME
+ */
+
+namespace DAME\Shortcodes;
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Handles the [dame_contact] shortcode and form submission.
+ */
+class Contact {
+
+	/**
+	 * Initializes the shortcode and AJAX handlers.
+	 */
+	public function init() {
+		add_shortcode( 'dame_contact', [ $this, 'render' ] );
+		add_action( 'wp_ajax_dame_submit_contact_form', [ $this, 'handle_submission' ] );
+		add_action( 'wp_ajax_nopriv_dame_submit_contact_form', [ $this, 'handle_submission' ] );
+	}
+
+	/**
+	 * Renders the shortcode.
+	 *
+	 * @param array $atts Shortcode attributes.
+	 * @return string The HTML output of the contact form.
+	 */
+	public function render( $atts ) {
+		// Enqueue the script using the global constant
+		wp_enqueue_script( 'dame-contact-form', \DAME_PLUGIN_URL . 'public/js/contact-form.js', [ 'jquery' ], \DAME_VERSION, true );
+
+		// Localize the script with required data
+		wp_localize_script( 'dame-contact-form', 'dame_contact_ajax', [
+			'ajax_url' => admin_url( 'admin-ajax.php' ),
+			'nonce'    => wp_create_nonce( 'dame_contact_nonce' ),
+		] );
+
+		ob_start();
+		?>
+		<div id="dame-contact-form-wrapper">
+			<form id="dame-contact-form" class="dame-form" novalidate>
+
+				<?php wp_nonce_field( 'dame_contact_nonce', 'dame_contact_nonce_field' ); ?>
+
+				<!-- Honeypot -->
+				<div style="display:none;">
+					<label for="dame_contact_hp"><?php _e( "Laissez ce champ vide", "dame" ); ?></label>
+					<input type="text" id="dame_contact_hp" name="dame_contact_hp" value="">
+				</div>
+
+				<p>
+					<label for="dame_contact_name"><?php _e( "Nom", "dame" ); ?> <span class="required">*</span></label>
+					<input type="text" id="dame_contact_name" name="dame_contact_name" required>
+				</p>
+
+				<p>
+					<label for="dame_contact_email"><?php _e( "Courriel", "dame" ); ?> <span class="required">*</span></label>
+					<input type="email" id="dame_contact_email" name="dame_contact_email" required>
+				</p>
+
+				<p>
+					<label for="dame_contact_subject"><?php _e( "Sujet", "dame" ); ?> <span class="required">*</span></label>
+					<input type="text" id="dame_contact_subject" name="dame_contact_subject" required>
+				</p>
+
+				<p>
+					<label for="dame_contact_message"><?php _e( "Message", "dame" ); ?> <span class="required">*</span></label>
+					<textarea id="dame_contact_message" name="dame_contact_message" rows="5" required></textarea>
+				</p>
+
+				<p>
+					<button type="submit"><?php _e( "Envoyer", "dame" ); ?></button>
+					<span id="dame-contact-form-messages" style="margin-left: 10px;"></span>
+				</p>
+
+			</form>
+		</div>
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
+	 * Handles the AJAX submission for the contact form.
+	 */
+	public function handle_submission() {
+		// 1. Security Check: Verify nonce
+		if ( ! isset( $_POST['dame_contact_nonce_field'] ) || ! wp_verify_nonce( $_POST['dame_contact_nonce_field'], 'dame_contact_nonce' ) ) {
+			wp_send_json_error( [ 'message' => __( "La vérification de sécurité a échoué. Veuillez rafraîchir la page.", "dame" ) ], 403 );
+		}
+
+		// Honeypot Check
+		if ( ! empty( $_POST['dame_contact_hp'] ) ) {
+			// Silently fail for bots
+			wp_send_json_success( [ 'message' => __( "Votre message a bien été envoyé.", "dame" ) ] );
+		}
+
+		// 2. Validation
+		$errors          = [];
+		$required_fields = [
+			'dame_contact_name'    => __( "Le nom est obligatoire.", "dame" ),
+			'dame_contact_email'   => __( "Le courriel est obligatoire.", "dame" ),
+			'dame_contact_subject' => __( "Le sujet est obligatoire.", "dame" ),
+			'dame_contact_message' => __( "Le message est obligatoire.", "dame" ),
+		];
+
+		foreach ( $required_fields as $field_key => $error_message ) {
+			if ( empty( $_POST[ $field_key ] ) ) {
+				$errors[] = $error_message;
+			}
+		}
+
+		// Email format validation
+		if ( ! empty( $_POST['dame_contact_email'] ) && ! is_email( $_POST['dame_contact_email'] ) ) {
+			$errors[] = __( "L'adresse de courriel n'est pas valide.", "dame" );
+		}
+
+		if ( ! empty( $errors ) ) {
+			wp_send_json_error( [ 'message' => implode( ' ', $errors ) ], 400 );
+		}
+
+		// 3. Sanitize Data
+		$name    = sanitize_text_field( wp_unslash( $_POST['dame_contact_name'] ) );
+		$email   = sanitize_email( wp_unslash( $_POST['dame_contact_email'] ) );
+		$subject = sanitize_text_field( wp_unslash( $_POST['dame_contact_subject'] ) );
+		$message = sanitize_textarea_field( wp_unslash( $_POST['dame_contact_message'] ) );
+
+		// 4. Send Email
+		$options = get_option( 'dame_options' );
+		$to      = isset( $options['sender_email'] ) && is_email( $options['sender_email'] ) ? $options['sender_email'] : get_option( 'admin_email' );
+
+		$email_subject = "Formulaire de contact - " . $subject;
+
+		$body  = "Vous avez reçu un nouveau message depuis le formulaire de contact de votre site.\r\n\r\n";
+		$body .= "Nom: " . $name . "\r\n";
+		$body .= "Courriel: " . $email . "\r\n";
+		$body .= "Sujet: " . $subject . "\r\n";
+		$body .= "Message:\r\n" . $message . "\r\n";
+
+		$headers = [ 'From: ' . $name . ' <' . $email . '>' ];
+
+		$sent = wp_mail( $to, $email_subject, $body, $headers );
+
+		if ( $sent ) {
+			wp_send_json_success( [ 'message' => __( "Votre message a bien été envoyé.", "dame" ) ] );
+		} else {
+			wp_send_json_error( [ 'message' => __( "Une erreur s'est produite lors de l'envoi du message.", "dame" ) ] );
+		}
+	}
+}

--- a/public/js/contact-form.js
+++ b/public/js/contact-form.js
@@ -1,55 +1,67 @@
-(function($) {
-    'use strict';
+document.addEventListener('DOMContentLoaded', function() {
+    const form = document.getElementById('dame-contact-form');
+    const feedback = document.getElementById('dame-contact-feedback');
 
-    $(document).ready(function() {
-        $('#dame-contact-form').on('submit', function(e) {
+    if (form) {
+        form.addEventListener('submit', function(e) {
             e.preventDefault();
 
-            var form = $(this);
-            var messageContainer = $('#dame-contact-form-messages');
-            var submitButton = form.find('button[type="submit"]');
-
-            // Clear previous messages
-            messageContainer.text('').removeClass('success error');
-
-            // Client-side validation
-            var name = $('#dame_contact_name').val();
-            var email = $('#dame_contact_email').val();
-            var subject = $('#dame_contact_subject').val();
-            var message = $('#dame_contact_message').val();
-
-            if (!name || !email || !subject || !message) {
-                messageContainer.text('Veuillez remplir tous les champs obligatoires.').css('color', 'red');
+            // Validation HTML5 basique
+            if (!form.checkValidity()) {
+                form.reportValidity();
                 return;
             }
 
-            // Disable button
-            submitButton.prop('disabled', true);
-            messageContainer.text('Envoi en cours...').css('color', 'inherit');
+            // Récupération des données du formulaire (incluant le champ caché 'action')
+            const formData = new FormData(form);
 
-            var formData = form.serialize();
+            // Sécurité : si le JS n'avait pas le champ action, on le force au cas où
+            if (!formData.has('action')) {
+                formData.append('action', 'dame_submit_contact_form');
+            }
 
-            $.ajax({
-                type: 'POST',
-                url: dame_contact_ajax.ajax_url,
-                data: formData + '&action=dame_contact_submit',
-                success: function(response) {
-                    if (response.success) {
-                        messageContainer.text(response.data.message).css('color', 'green');
-                        form.trigger('reset'); // Clear form fields
-                    } else {
-                        messageContainer.text(response.data.message).css('color', 'red');
-                    }
-                },
-                error: function() {
-                    messageContainer.text('Une erreur est survenue. Veuillez réessayer.').css('color', 'red');
-                },
-                complete: function() {
-                    // Re-enable button
-                    submitButton.prop('disabled', false);
+            const submitBtn = form.querySelector('button[type="submit"]');
+            const originalBtnText = submitBtn ? submitBtn.innerHTML : '';
+
+            if (submitBtn) {
+                submitBtn.disabled = true;
+                submitBtn.innerHTML = 'Envoi en cours...';
+            }
+
+            // Requête AJAX
+            fetch(dame_contact_ajax.ajax_url, {
+                method: 'POST',
+                body: formData
+            })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Erreur réseau (' + response.status + ')');
+                }
+                return response.json();
+            })
+            .then(data => {
+                feedback.style.display = 'block';
+                if (data.success) {
+                    // Les données viennent de data.data['message'] car data.data est l'objet passé à wp_send_json_success()
+                    let message = data.data.message ? data.data.message : data.data;
+                    feedback.innerHTML = '<div class="notice notice-success" style="color: green; padding: 10px; border: 1px solid green; margin-top: 15px;">' + message + '</div>';
+                    form.reset();
+                } else {
+                    let message = data.data.message ? data.data.message : data.data;
+                    feedback.innerHTML = '<div class="notice notice-error" style="color: red; padding: 10px; border: 1px solid red; margin-top: 15px;">' + message + '</div>';
+                }
+            })
+            .catch(error => {
+                feedback.style.display = 'block';
+                feedback.innerHTML = '<div class="notice notice-error" style="color: red; padding: 10px; border: 1px solid red; margin-top: 15px;">Erreur de connexion au serveur. Veuillez réessayer.</div>';
+                console.error('Erreur AJAX Contact:', error);
+            })
+            .finally(() => {
+                if (submitBtn) {
+                    submitBtn.disabled = false;
+                    submitBtn.innerHTML = originalBtnText;
                 }
             });
         });
-    });
-
-})(jQuery);
+    }
+});


### PR DESCRIPTION
This submission fixes the `400 Bad Request` issue when submitting the contact form. It updates `includes/Shortcodes/Contact.php` to include a hidden `action` field explicitly in the HTML and a new feedback div for displaying messages. It also completely rewrites `public/js/contact-form.js` to use `fetch()` and `FormData`, making it robust and directly compatible with WordPress AJAX.

---
*PR created automatically by Jules for task [2610260126956786028](https://jules.google.com/task/2610260126956786028) started by @Trollinou*