### PR TITLE
Refactor: Migrate admin toolbar to OOP architecture

### DIFF
--- a/includes/Admin/Toolbar.php
+++ b/includes/Admin/Toolbar.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * File for handling the admin toolbar menu.
+ *
+ * @package DAME
+ */
+
+namespace DAME\Admin;
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Handles the admin toolbar integration.
+ */
+class Toolbar {
+
+	/**
+	 * Initializes the toolbar hooks.
+	 */
+	public function init() {
+		add_action( 'admin_bar_menu', [ $this, 'add_nodes' ], 999 );
+		add_action( 'admin_action_dame_manual_backup', [ $this, 'handle_manual_backup' ] );
+		add_action( 'admin_notices', [ $this, 'show_backup_notice' ] );
+	}
+
+	/**
+	 * Adds the DAME menu to the WordPress admin bar.
+	 *
+	 * @param \WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+	 */
+	public function add_nodes( $wp_admin_bar ) {
+		// Add the main DAME menu item.
+		$wp_admin_bar->add_node(
+			[
+				'id'    => 'dame_menu',
+				'title' => '<span class="ab-icon">&#x265F;</span>' . __( "DAME", "dame" ),
+				'href'  => admin_url( 'edit.php?post_type=adherent' ),
+			]
+		);
+
+		// Add the "Voir les préinscriptions" sub-menu item.
+		$wp_admin_bar->add_node(
+			[
+				'id'     => 'dame_view_preinscriptions',
+				'parent' => 'dame_menu',
+				'title'  => __( "Voir les préinscriptions", "dame" ),
+				'href'   => admin_url( 'edit.php?post_type=dame_pre_inscription' ),
+			]
+		);
+
+		// Add the "Envoyer un article" sub-menu item.
+		$wp_admin_bar->add_node(
+			[
+				'id'     => 'dame_send_article',
+				'parent' => 'dame_menu',
+				'title'  => __( "Envoyer un article", "dame" ),
+				'href'   => admin_url( 'edit.php?post_type=adherent&page=dame-mailing' ),
+			]
+		);
+
+		// Add the "Faire une sauvegarde" sub-menu item.
+		$backup_url = wp_nonce_url( admin_url( 'admin.php?action=dame_manual_backup' ), 'dame_manual_backup_nonce' );
+
+		$wp_admin_bar->add_node(
+			[
+				'id'     => 'dame_manual_backup',
+				'parent' => 'dame_menu',
+				'title'  => __( "Faire une sauvegarde", "dame" ),
+				'href'   => $backup_url,
+			]
+		);
+	}
+
+	/**
+	 * Handles the manual backup trigger from the admin bar.
+	 */
+	public function handle_manual_backup() {
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_GET['_wpnonce'] ), 'dame_manual_backup_nonce' ) ) {
+			wp_die( __( "Invalid nonce.", "dame" ) );
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( __( "You do not have sufficient permissions to perform this action.", "dame" ) );
+		}
+
+		// Trigger the backup.
+		do_action( 'dame_daily_backup_event' );
+
+		// Redirect back to the dashboard with a success message.
+		wp_safe_redirect( add_query_arg( 'dame_backup_triggered', '1', admin_url() ) );
+		exit;
+	}
+
+	/**
+	 * Displays an admin notice when the manual backup is triggered.
+	 */
+	public function show_backup_notice() {
+		if ( isset( $_GET['dame_backup_triggered'] ) && '1' === $_GET['dame_backup_triggered'] ) {
+			?>
+			<div class="notice notice-success is-dismissible">
+				<p><?php esc_html_e( "La sauvegarde a été déclenchée avec succès.", "dame" ); ?></p>
+			</div>
+			<?php
+		}
+	}
+}

--- a/includes/Core/Plugin.php
+++ b/includes/Core/Plugin.php
@@ -49,6 +49,7 @@ use DAME\Admin\Actions\Agenda as AgendaActions;
 use DAME\Taxonomies\Season;
 use DAME\Taxonomies\Group;
 use DAME\Taxonomies\AgendaCategory;
+use DAME\Admin\Toolbar;
 
 /**
  * The core plugin class.
@@ -165,6 +166,10 @@ class Plugin {
 
 		$agenda_category_taxonomy = new AgendaCategory();
 		$agenda_category_taxonomy->init();
+
+		// Initialisation de la Toolbar
+		$toolbar = new Toolbar();
+		$toolbar->init();
 
 		// Initialize Metaboxes & Admin-only logic.
 		if ( is_admin() ) {


### PR DESCRIPTION
This commit migrates the legacy `old-sources/includes/toolbar.php` file to a PSR-4 compliant `DAME\Admin\Toolbar` class.

Key changes:
- All logic has been encapsulated in the `DAME\Admin\Toolbar` class.
- The class is instantiated in `includes/Core/Plugin.php` outside the `is_admin()` block to ensure it works on the frontend as well.
- The backup mechanism now hooks into the new architecture (`do_action( 'dame_daily_backup_event' )`).
- All `__()` and `_e()` string translations strictly use double quotes (`"`) as per the `AGENTS.md` guidelines for French text compatibility.

---
*PR created automatically by Jules for task [13049996917293460897](https://jules.google.com/task/13049996917293460897) started by @Trollinou*