### PR TITLE
Rename "DAME" submenu to "Tableau de bord"

### DIFF
--- a/includes/Admin/Menu.php
+++ b/includes/Admin/Menu.php
@@ -86,7 +86,7 @@ class Menu {
 		$reordered = [];
 
 		$desired_order = [
-			'dame-admin' => __( "DAME", "dame" ),
+			'dame-admin' => __( "Tableau de bord", "dame" ),
 			'edit.php?post_type=adherent' => __( "Tous les adhérents", "dame" ),
 			'edit.php?post_type=dame_pre_inscription' => __( "Toutes les préinscriptions", "dame" ),
 			'edit-tags.php?taxonomy=dame_saison_adhesion&amp;post_type=adherent' => __( "Saisons d'adhésion", "dame" ),


### PR DESCRIPTION
This change renames the first submenu item of the DAME admin menu from "DAME" to "Tableau de bord" for better clarity, as requested by the user.

---
*PR created automatically by Jules for task [10234157602304813787](https://jules.google.com/task/10234157602304813787) started by @Trollinou*